### PR TITLE
Remove Web SDK link due to its deprecation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Payment service technical documentation
 BazaarPay provides merchants with multiple payment solutions, and SDKs for easy and fast adoption, including:
 
 - [Android SDK](https://github.com/cafebazaar/BazaarPay)
-- [Web SDK](https://www.npmjs.com/package/@cafebazaar/payment-sdk)
 - SDK-Less Payment
 
 We also provide [direct payment service](./fa/direct-pay.md) for easier payments and better user experience.


### PR DESCRIPTION
لینکی که برای Web SDK هست ولید نیست و فعلا پکیجی که بهش لینک دادیم حذف شده.